### PR TITLE
Alter system to fix udhcpd startup

### DIFF
--- a/playbooks/roles/cli_base_rpi/tasks/main.yml
+++ b/playbooks/roles/cli_base_rpi/tasks/main.yml
@@ -43,6 +43,12 @@
     - ruby1.9.3                  # ruby
     - exuberant-ctags            # vim file navigation
     - vim-gnome                  # vim!
+    - mlocate                    # For locating files on the RPI
+    - iptraf                     # IP traffic monitor
+    - subversion                 # Alternate scm software
+    - strace                     # Util for diagnosing binary problems
+    - tcpdump                    # Util for watching ip traffic
+    - ntpdate                    # NTP util to suppliment ntpd
     # - redis-server               # redis
     # - postgresql-9.1             # postgres
     # - pgadmin3                   # pgadmin

--- a/playbooks/roles/hotspot_rpi/tasks/main.yml
+++ b/playbooks/roles/hotspot_rpi/tasks/main.yml
@@ -25,6 +25,10 @@
     dest: /usr/sbin/hostapd
     mode: "a+rx"
 
+- name: Revert verison of hostapd if using a rt2x00usb card
+  sudo: true
+  shell: lsmod | grep rt2x00usb; if [ $? -eq 0 ]; then cp -a /usr/sbin/hostapd /usr/sbin/hostapd.alternate; rm -f /usr/sbin/hostapd; cp -a /usr/sbin/hostapd.backup /usr/sbin/hostapd; fi 
+
 - name: fix an error in /etc/init.d/hostapd
   sudo: true
   lineinfile:
@@ -60,6 +64,14 @@
     dest:   /etc/default/hostapd
     regexp: '^DAEMON_CONF'
     line:   'DAEMON_CONF="/etc/hostapd/hostapd.conf"'
+
+- name: update udhcpd init to bring up wlan0 before starting
+  sudo: true
+  shell: sudo sed -i s=^set\ -e=set\ -e'\n'ifup\ wlan0=g /etc/init.d/udhcpd
+
+- name: update udhcpd init to touch leases file
+  sudo: true
+  shell: sudo sed -i s=^set\ -e=set\ -e'\n'touch\ /var/lib/misc/udhcpd.leases=g /etc/init.d/udhcpd   
 
 - name: setup network interfaces
   sudo: true

--- a/playbooks/roles/hotspot_rpi/tasks/main.yml
+++ b/playbooks/roles/hotspot_rpi/tasks/main.yml
@@ -14,6 +14,10 @@
     - bridge-utils # bridge-utils
     - iptables-persistent
 
+- name: Backup hostapd binary
+  sudo: true
+  shell: if [ ! -f /usr/sbin/hostapd.backup ]; then cp -a /usr/sbin/hostapd /usr/sbin/hostapd.backup; fi
+  
 - name: install a bug-fix version of hostapd
   sudo: true
   copy: 


### PR DESCRIPTION
The problem with udhcpd is that wlan0 isn't up when the server is starting up. This adds wlan0 to the init of udhcpd.

Then, I added a bit top switch back to the original hostapd only when a RTL usb card. 

This should close https://github.com/cinchcircuits/bamru_truck/issues/2 and https://github.com/cinchcircuits/bamru_truck/issues/7
